### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ let matches: RegexResults = test.extractMatches("welcome all", options: regexOpt
 
 ## Requirements
 
-A reasonably recent version of XCode
+A reasonably recent version of Xcode
 
 ## Installation
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
